### PR TITLE
Removal of withdrawn predictions from the overdue predictions list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,6 +56,7 @@ class UsersController < ApplicationController
   def due_for_judgement
     @title = "Predictions by #{@user} due for judgement"
     @predictions = @user.predictions
+    @predictions = @predictions.not_withdrawn
     @predictions = @predictions.not_private unless current_user == @user
     @predictions = @predictions.select { |x| x.due_for_judgement? }
   end


### PR DESCRIPTION
Hi! I'm an enthusiastic PredictionBook user, and while I find the user experience of PredictionBook mostly awesome, the bug where withdrawn predictions still show up in the list of unjudged predictions on your overdue predictions page (issue #48) is kind of annoying. I reckoned it would be an easy one-line fix to patch this bug, so I just went ahead and did it, and indeed it was a simple one-line fix.

Oh, and thanks for making PredictionBook! It truly is an excellent website.
