### PR TITLE
Bugfix for deadline validation

### DIFF
--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -56,7 +56,7 @@ class Prediction < ActiveRecord::Base
   validates_presence_of :description, :message => 'What are you predicting?'
   validates_presence_of :initial_confidence, :message => 'How sure are you?', :on => :create
   validate :confidence_on_response, :on => :create
-  validate :maximum_deadline, :on => :create
+  validate :bound_deadline
 
   after_validation do
     errors.add(:deadline_text, errors[:deadline])
@@ -186,9 +186,11 @@ class Prediction < ActiveRecord::Base
     end
   end
 
-  def maximum_deadline
+  def bound_deadline
     if !deadline.nil? && deadline.year > 9999
       errors.add(:deadline, "Please consider creating a time capsule to record this prediction.")
+    elsif !deadline.nil? && deadline.year < 1
+      errors.add(:deadline, "If it was known that long ago, it's not exactly a prediction, is it?")
     end
   end
 end

--- a/spec/models/prediction_spec.rb
+++ b/spec/models/prediction_spec.rb
@@ -49,6 +49,18 @@ describe Prediction do
         prediction.valid?
         prediction.should have(1).error_on(:deadline)
       end
+      it 'should not accept a deadline too far in the past to store' do
+        date = 300000.years.ago
+        prediction = Prediction.new(:deadline => date)
+        prediction.valid?
+        prediction.should have(1).error_on(:deadline)
+      end
+      it 'should not accept an invalid deadline even after being created' do
+        prediction = Prediction.new(:deadline => 2.months.from_now)
+        prediction.should have(0).error_on(:deadline)
+        prediction.deadline = 300000.years.from_now
+        prediction.should have(1).error_on(:deadline)
+      end
     end
   end
 


### PR DESCRIPTION
I found a **very** nasty bug in the deadline validation code.

When I tried exploiting it on my development server, it took down the site. I haven't dared to see if it would do the same in production, but I see no reason why it wouldn't.

The previous code did indeed check to make sure the deadline wasn't to far in the future to be safely storable, but there were two loopholes:
- There were no checks to ensure that the deadlines aren't to far in the _past_ to be storable. If you gave a prediction the deadline of "10000000 years ago", it would not be caught the way a deadline of "10000000 years from now" would be, and so promptly crash the site.
- The check was only made on creation of the prediction: If you made a prediction with a valid deadline, you could then edit its deadline to whatever you wanted without triggering validation, and thus crash the site.

I fixed both those loopholes, and added unit tests to ensure that they are correctly handled.
