### PR TITLE
Add score properly persists updated credence game

### DIFF
--- a/app/models/credence_question.rb
+++ b/app/models/credence_question.rb
@@ -4,6 +4,8 @@ class CredenceQuestion < ApplicationRecord
   has_many :answers, class_name: CredenceAnswer.name, dependent: :destroy, autosave: true
   has_many :responses, class_name: CredenceGameResponse.name, dependent: :destroy, autosave: true
 
+  scope :enabled, -> { where(enabled: true) }
+
   def build_random_response(game)
     random_answers = []
     answer_count = answers.size

--- a/spec/models/credence_game_spec.rb
+++ b/spec/models/credence_game_spec.rb
@@ -39,4 +39,38 @@ describe CredenceGame do
     expect(game.most_recently_answered(3).length).to eq 1
     expect(game.most_recently_answered(3).first).to eq last_response
   end
+
+  describe '#add_score' do
+    let(:question) { FactoryBot.create(:credence_question) }
+    let(:answers) do
+      FactoryBot.create_list(:credence_answer, 2, credence_question: question)
+    end
+    let(:game) { FactoryBot.create(:credence_game) }
+    let(:response) do
+      FactoryBot.create(
+        :credence_game_response,
+        credence_game: game, credence_question: question,
+        first_answer: answers.first, second_answer: answers.second
+      )
+    end
+    let(:other_response) { FactoryBot.create(:credence_game_response) }
+
+    it 'increments the number answered' do
+      response
+
+      expect{ game.add_score(1) }.to change{ game.num_answered }.from(0).to(1)
+    end
+
+    it 'increments the number answered' do
+      response
+
+      expect{ game.add_score(2) }.to change{ game.score }
+    end
+
+    it 'sets the current response' do
+      response && other_response
+
+      expect{ game.add_score(3) }.to change{ game.current_response }.from(nil)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #134

Before:
![before-fix](https://user-images.githubusercontent.com/1292454/118924274-b3512200-b8f1-11eb-8b11-85017acb8260.gif)
After:
![after-fix](https://user-images.githubusercontent.com/1292454/118924300-bf3ce400-b8f1-11eb-9360-9da1778f9cbd.gif)

I think @bmillwood was on the right track. My hypothesis is that [this](https://github.com/bellroy/predictionbook/commit/db0c77a9c7bcbd6e6a40f1620171df8c66e00cce#diff-f642632a5dde82c10851c04728491732665082689dd2214e43ed0f5435d38554R49) Rails upgrade caused a regression. It seems that some of the `#changed?`, `#saved_changes?`, etc... methods changed their semantics between 4.2 and 5.1, but AFAICT, saving doesn't need to be conditional here anyway.