### PR TITLE
Add gem ed25519 which is required for net-ssh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'hashdiff'
 gem 'honeypot-captcha', git: 'https://github.com/RandieM/honeypot-captcha'
 gem 'sentry-rails', '>= 4.0'
 gem 'sentry-ruby', '>= 4.0'
+# Gem ed25519 is required by net-ssh to allow deploys when using this host key: https://github.com/net-ssh/net-ssh#host-keys
+gem 'ed25519'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    ed25519 (1.3.0)
     email_spec (2.2.1)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -448,6 +449,7 @@ DEPENDENCIES
   coffee-rails
   database_cleaner
   devise
+  ed25519
   email_spec
   exception_notification
   execjs (~> 2.7.0)


### PR DESCRIPTION
Gem ed25519 is required by net-ssh to allow deploys when using ssh-ed25519 host key: https://github.com/net-ssh/net-ssh#host-keys