### PR TITLE
Add bcrypt_pbkdf gem and sources update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'sentry-rails', '>= 4.0'
 gem 'sentry-ruby', '>= 4.0'
 # Gem ed25519 is required by net-ssh to allow deploys when using this host key: https://github.com/net-ssh/net-ssh#host-keys
 gem 'ed25519'
+gem 'bcrypt_pbkdf'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     awesome_print (1.9.2)
     bcrypt (3.1.18)
+    bcrypt_pbkdf (1.1.0)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -436,6 +437,7 @@ DEPENDENCIES
   RedCloth
   active_model_serializers
   awesome_print
+  bcrypt_pbkdf
   better_errors
   binding_of_caller
   bullet
@@ -501,4 +503,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.9
+   2.3.25

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "22.05",
-        "description": "Nix packages collection",
+        "branch": "nixos-22.11",
+        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce6aa13369b667ac2542593170993504932eb836",
-        "sha256": "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik",
+        "rev": "2d10e73416ec1449ef74aeac7faf2cf8c556ff5a",
+        "sha256": "00s89np0sqr3jxxp5h9nrpqy30fy4vsrmis6mmryrrmjqh09lpfv",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ce6aa13369b667ac2542593170993504932eb836.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2d10e73416ec1449ef74aeac7faf2cf8c556ff5a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR adds `bcrypt_pbkdf` to the Gemfile. It also updates Nixos channel to run the latest version.
`net-ssh` requires `bcrypt_pbkdf` to decrypt the `ed25519` ssh keys.
